### PR TITLE
Update Adafruit hardware support documentation to reflect to support for additional boards and displays.

### DIFF
--- a/docs/hardware/adafruit/featherwing.md
+++ b/docs/hardware/adafruit/featherwing.md
@@ -1,4 +1,4 @@
-# Adafruit Featherwing
+# Adafruit
 
 <div class="row justify-content-center">
     <a href="../images/featherwing24.png" data-toggle="lightbox" data-gallery="example-gallery" class="col-sm-6" data-title="<a href='https://learn.adafruit.com/3d-printed-case-for-adafruit-feather/tft-feather-wing'>Adafruit Featherwing 2.4&quot;</a>" data-footer="Original image by <a href='https://learn.adafruit.com/assets/40718'>Ruiz Brothers</a> - LICENSE: <a href='https://creativecommons.org/licenses/by-sa/3.0/'>Attribution-ShareAlike Creative Commons</a>">
@@ -9,17 +9,29 @@
     </a>
 </div>
 
-You can run openHASP on the Adafruit HUZZAH32 – ESP32 Feather Board with a TFT Featherwing display.
-We provide pre-build firmware for this hardware combo. You can pick the 2.4" or 3.5" touchscreen.
+openHASP runs on Adafruit's ESP32 Feather Boards and supports Adafruit's TFT Featherwing resistive touch screens. Build configurations and precompiled firmware binaries are available for these popular hardware combinations to help you get started quickly.
 
-The TFT Featherwing comes in 2 sizes:
+## Supported Boards
 
-- [TFT FeatherWing - 2.4" 320x240 Touchscreen](https://www.adafruit.com/product/3315): ILI9341 with STMPE610 resistive touch
-- [TFT FeatherWing - 3.5" 480x320 Touchscreen](https://www.adafruit.com/product/3651): HX8357D with STMPE610 resistive touch
+openHASP supports the following Adafruit Feather boards (and the many different versions and variations based on them)
 
-## Development Boards
+- Adafruit HUZZAH32 - ESP32 Feather (4MB Flash, No PSRAM)
+- Adafruit ESP32-S3 Feather (4MB Flash, 2MB PSRAM)
+- Adafruit ESP32 Feather V2 (8MB Flash, 2MB PSRAM)
 
-### HUZZAH32
+These boards are virtually plug-and-play when combined with Adafruit TFT FeatherWing displays. Many of these boards come in versions with pre-soldered headers (no soldering required)
+
+!!! note "  Note" Don't use the Adafruit ESP8266-based Feather HUZZAH board as it lacks both sufficient memory and MCU power.
+
+!!! note "  Note" Boards with PSRAM are highly recommended, and required for image processing.
+
+
+## Supported Displays
+
+- TFT FeatherWing - 2.4" 320x240 Touchscreen *(ILI9341 with STMPE610 resistive touch)*
+- [TFT FeatherWing - 2.4" 320x240 Touchscreen V2](https://www.adafruit.com/product/3315) *(ILI9341 with TSC2007 resistive touch)*
+- TFT FeatherWing - 3.5" 480x320 Touchscreen *(HX8357D with STMPE610 resistive touch)*
+- [TFT FeatherWing - 3.5" 480x320 Touchscreen V2](https://www.adafruit.com/product/3651): *(HX8357D with TSC2007 resistive touch)*
 
 <div class="row justify-content-center">
     <a href="../images/feather_3405_iso_ORIG.jpg" data-toggle="lightbox" data-gallery="example-gallery" class="col-sm-4" data-title="<a href='https://learn.adafruit.com/3d-printed-case-for-adafruit-feather/tft-feather-wing'>TFT Feather Wing Enclosure</a>" data-footer="Original image by <a href='https://learn.adafruit.com/users/adafruit2'>lady ada</a> - All rights reserved">
@@ -33,29 +45,11 @@ The TFT Featherwing comes in 2 sizes:
     </a>
 </div>
 
-The HUZZAH32 – ESP32 Feather Boards come in 3 versions:
-
-- [No headers soldered](https://www.adafruit.com/product/3405)
-- [Headers pre-soldered](https://www.adafruit.com/product/3591)
-- [Stacking headers pre-soldered](https://www.adafruit.com/product/3619)
-
-!!! note "<i class='fa fa-info-circle'></i>&nbsp; Note" 
-    Don't use the ESP8266 based Feather HUZZAH because it lacks both in memory and MCU power.
-
-The HUZZAH32 – ESP32 and TFT Featherwings are plug-and-play. You only need to upload the firmware via the USB port.
-If you get a version with pre-soldered headers then no soldering is required to get started!
-
-Check out the Adafruit [TFT Featherwing tutorial](https://learn.adafruit.com/adafruit-2-4-tft-touch-screen-featherwing) on learn.adafruit.com.
-It contains more detailed information, tutorials and wiring diagrams.
-
-The Huzzah32 boards only have 4MB flash. If you want more storage, consider getting the SparkFun Thing Plus ESP32-WROOM instead.
-
+Check out Adafruit's [TFT Featherwing tutorial](https://learn.adafruit.com/adafruit-2-4-tft-touch-screen-featherwing) on [learn.adafruit.com](https://learn.adafruit.com/) for detailed information and wiring diagrams.
 
 ## Backlight
 
-By default the display is always on. To get the dimmable backlight working you *do* need to solder 2 pads!
-There is a `Lite` pin which is not connected to any pads but you can connect it to control the backlight.
-You can connect it to a PWM output pin, like `GPIO 21`:
+By default, the display is always on and at its maximum brightness. To control backlight dimming or sleeping, you need to solder the `LITE` pin to a PWM output pin (e.g., `GPIO 21`).
 
 <div class="row justify-content-center">
             <a href="../images/featherwing35-backlight.png" data-toggle="lightbox" data-gallery="example-gallery" class="col-sm-8" data-title="Backlight Control" data-footer="Original image by altersis">
@@ -63,30 +57,40 @@ You can connect it to a PWM output pin, like `GPIO 21`:
             </a>
 </div>
 
-## Product Video
+## Product Videos
 
-#### 2.4" TFT Featherwing
-
-<div class="embed-responsive embed-responsive-16by9" style="max-width:560px; margin:auto;">
-    <iframe title="YouTube video player" src="https://www.youtube.com/embed/0JUA1IHCI-o?start=630&end=0&rel=0&controls=1" class="embed-responsive-item" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-    </iframe>
-</div>
-
-#### 3.5" TFT Featherwing
+#### 2.4" TFT FeatherWing
 
 <div class="embed-responsive embed-responsive-16by9" style="max-width:560px; margin:auto;">
-    <iframe title="YouTube video player" src="https://www.youtube.com/embed/Wt_QXeipqpk?start=268&end=0&rel=0&controls=1" class="embed-responsive-item" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-    </iframe>
+  <iframe title="YouTube video player" src="https://www.youtube.com/embed/0JUA1IHCI-o?start=630&end=0&rel=0&controls=1" class="embed-responsive-item" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-## 3D Printed Case
+#### 2.4" TFT FeatherWing V2
 
-Check out these enclosures, the designs are available on Thingiverse:
+<div class="embed-responsive embed-responsive-16by9" style="max-width:560px; margin:auto;">
+  <iframe src="https://www.youtube.com/embed/tzbzjBJtPRQ?si=ZMKchMxkdbYuRPEF" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
 
-- [2.4" TFT Feather Wing Enclosure](https://learn.adafruit.com/3d-printed-case-for-adafruit-feather/tft-feather-wing){target=_blank}
-- [2.4" TFT Feather Wing Weather Station](https://www.thingiverse.com/thing:1944905){target=_blank}
-- [3.5" TFT Featherwing table top case](https://www.thingiverse.com/thing:2776163){target=_blank}
-- [3.5" TFT Featherwing Touch Deck](https://www.thingiverse.com/thing:4803265){target=_blank}
+#### 3.5" TFT FeatherWing
+
+<div class="embed-responsive embed-responsive-16by9" style="max-width:560px; margin:auto;">
+  <iframe title="YouTube video player" src="https://www.youtube.com/embed/Wt_QXeipqpk?start=268&end=0&rel=0&controls=1" class="embed-responsive-item" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+#### 3.5" TFT FeatherWing V2
+
+<div class="embed-responsive embed-responsive-16by9" style="max-width:560px; margin:auto;">
+  <iframe src="https://www.youtube.com/embed/h3zfPu5WHqk?si=2Q0JnpU36zkOPwuY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+## 3D Printed Cases
+
+Check out these enclosures available on Thingiverse:
+
+- [2.4" TFT FeatherWing Enclosure](https://learn.adafruit.com/3d-printed-case-for-adafruit-feather/tft-feather-wing){target=_blank}
+- [2.4" TFT FeatherWing Weather Station](https://www.thingiverse.com/thing:1944905){target=_blank}
+- [3.5" TFT FeatherWing Table Top Case](https://www.thingiverse.com/thing:2776163){target=_blank}
+- [3.5" TFT FeatherWing Touch Deck](https://www.thingiverse.com/thing:4803265){target=_blank}
 
 <div class="row justify-content-center">
     <a href="../images/3d_printing_done-assembly.gif" data-toggle="lightbox" data-gallery="example-gallery" class="col-sm-4" data-title="<a href='https://learn.adafruit.com/3d-printed-case-for-adafruit-feather/tft-feather-wing'>TFT Feather Wing Enclosure</a>" data-footer="Original image by <a href='https://learn.adafruit.com/assets/40717'>Ruiz Brothers</a> - LICENSE: <a href='https://creativecommons.org/licenses/by-sa/3.0/'>Attribution-ShareAlike Creative Commons</a>">


### PR DESCRIPTION
Reflects recent changes made in the [openHASP](https://github.com/amanaplan/openHASP) via the following merged pull requests:

- [Add support for updated Adafruit 2.4 and 3.5 TFT FeatherWings and HUZZAH32 board #613](https://github.com/HASwitchPlate/openHASP/pull/613) 
- [Corrected environment names for huzzah32-v2-* boards #615](https://github.com/HASwitchPlate/openHASP/pull/615)